### PR TITLE
Fixed some snippets

### DIFF
--- a/Snippets/init.sublime-snippet
+++ b/Snippets/init.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[
-init (${1:parameters}) {
+init(${1:parameters}) {
 	$2
 }
 ]]></content>
 	<tabTrigger>init</tabTrigger>
 	<scope>source.swift</scope>
-	<description>init (...) {...}</description>
+	<description>init(...) {...}</description>
 </snippet>

--- a/Snippets/subscript.sublime-snippet
+++ b/Snippets/subscript.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-subscript (${1:parameters}) -> ${2:ReturnType} {
+subscript(${1:parameters}) -> ${2:ReturnType} {
 	$3
 }
 ]]></content>

--- a/Snippets/switch.sublime-snippet
+++ b/Snippets/switch.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 switch ${1:control expression} {
-case: ${2:pattern}:
+case ${2:pattern}:
 	$3
 }
 ]]></content>


### PR DESCRIPTION
In conformance to "The Swift Programming Language" book,
there should be no space after "init" and "subscript".
