### PR TITLE
Updated swift snippet

### DIFF
--- a/Snippets/swift.sublime-snippet
+++ b/Snippets/swift.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-#!/usr/bin/env xcrun swift -i
+#!/usr/bin/env xcrun swift
 $0
 ]]></content>
 	<tabTrigger>swift</tabTrigger>


### PR DESCRIPTION
The swift interpreter no longer requires a `-i` flag
