### PR TITLE
Fix typo in 'function' to add support for function related syntax

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -488,7 +488,7 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>entity.type.funciton.swift</string>
+					<string>entity.type.function.swift</string>
 				</dict>
 			</dict>
 			<key>comment</key>


### PR DESCRIPTION
Fixing this typo will unbreak syntax for function names, adding support for highlighting, etc.